### PR TITLE
Alternative key bindings for up,down,esc

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -146,6 +146,11 @@ impl State {
             KeyPress {
                 keysym: keysyms::XKB_KEY_Escape,
                 ..
+            }
+            | KeyPress {
+                keysym: keysyms::XKB_KEY_c,
+                ctrl: true,
+                ..
             } => return true,
             KeyPress {
                 keysym: keysyms::XKB_KEY_BackSpace,
@@ -157,9 +162,19 @@ impl State {
             KeyPress {
                 keysym: keysyms::XKB_KEY_Up,
                 ..
+            }
+            | KeyPress {
+                keysym: keysyms::XKB_KEY_k,
+                ctrl: true,
+                ..
             } => self.selected_item = self.selected_item.saturating_sub(1),
             KeyPress {
                 keysym: keysyms::XKB_KEY_Down,
+                ..
+            }
+            | KeyPress {
+                keysym: keysyms::XKB_KEY_j,
+                ctrl: true,
                 ..
             } => self.selected_item = self.inner.entries_len().min(self.selected_item + 1),
             KeyPress {


### PR DESCRIPTION
I added alternative key bindings for Up, Down, Esc

Up: Ctrl-k
Down: Ctrl-j
Esc: Ctrl-c

I find these bindings more intuitive than the current ones, when you have a very keyboard focused workflow. The suggested bindings allows your hands to stay in the center of the keyboard while working.