### PR TITLE
fix: text and icon align middle

### DIFF
--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -69,7 +69,10 @@ impl<'a> Drawable for InputText<'a> {
             &DrawOptions::new(),
         );
 
-        let pos = Point::new(left_x_center + padding.left, point.y + margin.top + padding.top);
+        let pos = Point::new(
+            left_x_center + padding.left,
+            point.y + margin.top + padding.top
+        );
 
         self.params.font.draw(
             &mut dt,

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -71,7 +71,7 @@ impl<'a> Drawable for InputText<'a> {
 
         let pos = Point::new(
             left_x_center + padding.left,
-            point.y + margin.top + padding.top
+            point.y + margin.top + padding.top,
         );
 
         self.params.font.draw(

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -33,8 +33,10 @@ impl<'a> Drawable for InputText<'a> {
         let font_size = f32::from(self.params.font_size * scale);
 
         let mut padding = self.params.padding * f32::from(scale);
-        padding.top += 2.0;
-        padding.bottom += 5.0;
+        const PADDING_TOP: f32 = 2.0;
+        const PADDING_BOTTOM: f32 = 5.0;
+        padding.top += PADDING_TOP;
+        padding.bottom += PADDING_BOTTOM;
         let margin = self.params.margin * f32::from(scale);
 
         let border_diameter = padding.top + font_size + padding.bottom;

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -32,7 +32,9 @@ impl<'a> Drawable for InputText<'a> {
 
         let font_size = f32::from(self.params.font_size * scale);
 
-        let padding = self.params.padding * f32::from(scale);
+        let mut padding = self.params.padding * f32::from(scale);
+        padding.top += 2.0;
+        padding.bottom += 5.0;
         let margin = self.params.margin * f32::from(scale);
 
         let border_diameter = padding.top + font_size + padding.bottom;
@@ -65,7 +67,8 @@ impl<'a> Drawable for InputText<'a> {
             &DrawOptions::new(),
         );
 
-        let pos = Point::new(left_x_center + padding.left, point.y + margin.top);
+        let pos = Point::new(left_x_center + padding.left, point.y + margin.top + padding.top);
+
         self.params.font.draw(
             &mut dt,
             self.text,

--- a/src/draw/list_view.rs
+++ b/src/draw/list_view.rs
@@ -69,7 +69,7 @@ where
 
         let icon_size_f32 = f32::from(icon_size);
         let font_size = f32::from(self.params.font_size * scale);
-        let top_offset = point.y + margin.top + f32::abs(f32::min(font_size - icon_size_f32, 0.)) / 2.;
+        let top_offset = point.y + margin.top + (icon_size_f32 - font_size).max(0.) / 2.;
         let entry_height = font_size.max(icon_size_f32);
 
         let displayed_items = ((space.height - margin.top - margin.bottom + item_spacing)

--- a/src/draw/list_view.rs
+++ b/src/draw/list_view.rs
@@ -67,9 +67,9 @@ where
         let icon_size = self.params.icon_size * scale;
         let icon_spacing = self.params.icon_spacing * f32::from(scale);
 
-        let top_offset = point.y + margin.top;
-        let font_size = f32::from(self.params.font_size * scale);
         let icon_size_f32 = f32::from(icon_size);
+        let font_size = f32::from(self.params.font_size * scale);
+        let top_offset = point.y + margin.top + f32::abs((font_size - icon_size_f32) / 2.);
         let entry_height = font_size.max(icon_size_f32);
 
         let displayed_items = ((space.height - margin.top - margin.bottom + item_spacing)
@@ -104,7 +104,7 @@ where
                 if icon.width == icon.height && icon.height == i32::from(icon_size) {
                     dt.draw_image_at(
                         x_offset,
-                        y_offset + icon_size_f32 / 2.,
+                        y_offset + (font_size - icon_size_f32) / 2.,
                         icon,
                         &DrawOptions::default(),
                     );
@@ -113,7 +113,7 @@ where
                         icon_size_f32,
                         icon_size_f32,
                         x_offset,
-                        y_offset + icon_size_f32 / 2.,
+                        y_offset + (font_size - icon_size_f32) / 2.,
                         icon,
                         &DrawOptions::default(),
                     );

--- a/src/draw/list_view.rs
+++ b/src/draw/list_view.rs
@@ -69,7 +69,7 @@ where
 
         let icon_size_f32 = f32::from(icon_size);
         let font_size = f32::from(self.params.font_size * scale);
-        let top_offset = point.y + margin.top + f32::abs((font_size - icon_size_f32) / 2.);
+        let top_offset = point.y + margin.top + f32::abs(f32::min(font_size - icon_size_f32, 0.)) / 2.;
         let entry_height = font_size.max(icon_size_f32);
 
         let displayed_items = ((space.height - margin.top - margin.bottom + item_spacing)

--- a/src/font/fdue.rs
+++ b/src/font/fdue.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 use anyhow::Context;
-use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle};
+use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle, VerticalAlign};
 use once_cell::sync::Lazy;
 use raqote::{AntialiasMode, DrawOptions, DrawTarget, Point, SolidSource};
 use rust_fontconfig::{FcFontCache, FcFontPath, FcPattern, PatternMatch};
@@ -92,6 +92,8 @@ impl FontBackend for Font {
         layout.reset(&LayoutSettings {
             x: start_pos.x,
             y: start_pos.y,
+            max_height: Some(font_size),
+            vertical_align: VerticalAlign::Middle,
             ..LayoutSettings::default()
         });
 
@@ -122,7 +124,7 @@ impl FontBackend for Font {
                 height,
                 data: &buf[..],
             };
-
+            
             dt.draw_image_with_size_at(g.width as f32, g.height as f32, g.x, g.y, &img, opts);
         }
     }

--- a/src/font/fdue.rs
+++ b/src/font/fdue.rs
@@ -124,7 +124,7 @@ impl FontBackend for Font {
                 height,
                 data: &buf[..],
             };
-            
+
             dt.draw_image_with_size_at(g.width as f32, g.height as f32, g.x, g.y, &img, opts);
         }
     }


### PR DESCRIPTION
It makes:
1) Inner padding in `input_text` more accurate.
2) Center icon to text (vice versa in case bigger icon)

credits: @filtsin 