### PR TITLE
Support desktop actions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ struct InputText {
     padding: Option<Padding>,
 }
 
-#[derive(Deserialize)]
+#[derive(Default, Deserialize)]
 struct ListItems {
     font: Option<String>,
     font_size: Option<u16>,
@@ -117,6 +117,7 @@ struct ListItems {
     selected_font_color: Option<Color>,
     match_color: Option<Color>,
     margin: Option<Margin>,
+    hide_actions: Option<bool>,
     action_left_margin: Option<f32>,
     item_spacing: Option<f32>,
     icon_spacing: Option<f32>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,7 @@ struct ListItems {
     selected_font_color: Option<Color>,
     match_color: Option<Color>,
     margin: Option<Margin>,
+    action_left_margin: Option<f32>,
     item_spacing: Option<f32>,
     icon_spacing: Option<f32>,
 }

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -67,6 +67,7 @@ impl<'a> From<&'a Config> for ListParams {
                 top: 10.0,
                 ..Margin::from_pair(5.0, 15.0)
             }),
+            hide_actions: select_conf!(noglob: config, list_items, hide_actions).unwrap_or(false),
             action_left_margin: select_conf!(noglob: config, list_items, action_left_margin)
                 .unwrap_or(60.0),
             item_spacing: select_conf!(noglob: config, list_items, item_spacing).unwrap_or(2.0),

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -67,6 +67,8 @@ impl<'a> From<&'a Config> for ListParams {
                 top: 10.0,
                 ..Margin::from_pair(5.0, 15.0)
             }),
+            action_left_margin: select_conf!(noglob: config, list_items, action_left_margin)
+                .unwrap_or(60.0),
             item_spacing: select_conf!(noglob: config, list_items, item_spacing).unwrap_or(2.0),
             icon_spacing: select_conf!(noglob: config, list_items, icon_spacing).unwrap_or(10.0),
         }

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -27,12 +27,8 @@ pub struct Entry {
 }
 
 impl Entry {
-    pub fn name(&self, action: usize) -> String {
-        if action == 0 {
-            self.entry.name.clone()
-        } else {
-            format!("{} [{}]", self.entry.name, self.actions[action - 1].name)
-        }
+    pub fn subname(&self, action: usize) -> Option<&str> {
+        self.actions.get(action - 1).map(|a| a.name.as_ref())
     }
 
     pub fn icon(&self, action: usize) -> Option<&Icon> {

--- a/src/draw/list_view.rs
+++ b/src/draw/list_view.rs
@@ -24,7 +24,7 @@ pub struct Params {
 }
 
 pub struct ListItem<'a> {
-    pub name: &'a str,
+    pub name: String,
     pub icon: Option<Image<'a>>,
     pub match_mask: Option<&'a BitVec>,
 }
@@ -138,7 +138,7 @@ where
 
             let color = if let Some(match_color) = self.params.match_color {
                 let mut special_color =
-                    vec![color; UnicodeSegmentation::graphemes(item.name, true).count()];
+                    vec![color; UnicodeSegmentation::graphemes(item.name.as_str(), true).count()];
 
                 let special_len = special_color.len();
 
@@ -168,7 +168,14 @@ where
             };
 
             let font = &self.params.font;
-            font.draw(&mut dt, item.name, font_size, pos, color, &draw_opts);
+            font.draw(
+                &mut dt,
+                item.name.as_str(),
+                font_size,
+                pos,
+                color,
+                &draw_opts,
+            );
         }
 
         space

--- a/src/draw/list_view.rs
+++ b/src/draw/list_view.rs
@@ -19,12 +19,14 @@ pub struct Params {
     pub icon_size: u16,
     pub fallback_icon: Option<crate::icon::Icon>,
     pub margin: Margin,
+    pub action_left_margin: f32,
     pub item_spacing: f32,
     pub icon_spacing: f32,
 }
 
 pub struct ListItem<'a> {
-    pub name: String,
+    pub name: &'a str,
+    pub subname: Option<&'a str>,
     pub icon: Option<Image<'a>>,
     pub match_mask: Option<&'a BitVec>,
 }
@@ -72,8 +74,14 @@ where
         let top_offset = point.y + margin.top + (icon_size_f32 - font_size).max(0.) / 2.;
         let entry_height = font_size.max(icon_size_f32);
 
+        let mut iter = self.items.peekable();
+
+        // For now either all items has subname or none.
+        let has_subname = iter.peek().map(|e| e.subname.is_some()).unwrap_or(false);
+
         let displayed_items = ((space.height - margin.top - margin.bottom + item_spacing)
-            / (entry_height + item_spacing)) as usize;
+            / (entry_height + item_spacing)) as usize
+            - has_subname as usize;
 
         let max_offset = self.skip_offset + displayed_items;
         let (selected_item, skip_offset) = if self.selected_item < self.skip_offset {
@@ -89,13 +97,9 @@ where
 
         self.new_skip.send(skip_offset).unwrap();
 
-        for (i, item) in self
-            .items
-            .skip(skip_offset)
-            .enumerate()
-            .take(displayed_items)
-        {
-            let relative_offset = (i as f32) * (entry_height + item_spacing);
+        for (i, item) in iter.skip(skip_offset).enumerate().take(displayed_items) {
+            let relative_offset =
+                (i as f32 + (i > selected_item) as i32 as f32) * (entry_height + item_spacing);
             let x_offset = point.x + margin.left;
             let y_offset = top_offset + relative_offset;
 
@@ -138,7 +142,7 @@ where
 
             let color = if let Some(match_color) = self.params.match_color {
                 let mut special_color =
-                    vec![color; UnicodeSegmentation::graphemes(item.name.as_str(), true).count()];
+                    vec![color; UnicodeSegmentation::graphemes(item.name, true).count()];
 
                 let special_len = special_color.len();
 
@@ -168,14 +172,20 @@ where
             };
 
             let font = &self.params.font;
-            font.draw(
-                &mut dt,
-                item.name.as_str(),
-                font_size,
-                pos,
-                color,
-                &draw_opts,
-            );
+            font.draw(&mut dt, item.name, font_size, pos, color, &draw_opts);
+            if let Some(subname) = item.subname.filter(|_| i == selected_item) {
+                font.draw(
+                    &mut dt,
+                    subname,
+                    font_size,
+                    Point::new(
+                        pos.x + self.params.action_left_margin,
+                        pos.y + entry_height + item_spacing,
+                    ),
+                    FontColor::Single(self.params.font_color),
+                    &draw_opts,
+                );
+            }
         }
 
         space

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
 
             if list {
                 for e in entries {
-                    println!("{}: {}", e.name, e.desktop_fname);
+                    println!("{}: {}", e.entry.name, e.desktop_fname);
                 }
                 return;
             }

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -53,7 +53,8 @@ pub enum Mode {
 }
 
 pub struct Entry<'a> {
-    pub name: String,
+    pub name: &'a str,
+    pub subname: Option<&'a str>,
     pub icon: Option<Image<'a>>,
 }
 

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -34,6 +34,7 @@ macro_rules! delegate {
 
 pub struct EvalInfo<'a> {
     pub index: Option<usize>,
+    pub subindex: usize,
     pub input_value: &'a InputValue<'a>,
 }
 
@@ -52,7 +53,7 @@ pub enum Mode {
 }
 
 pub struct Entry<'a> {
-    pub name: &'a str,
+    pub name: String,
     pub icon: Option<Image<'a>>,
 }
 
@@ -71,7 +72,8 @@ impl Mode {
 
     delegate!(pub fn eval(&mut self, info: EvalInfo<'_>) -> std::convert::Infallible);
     delegate!(pub fn entries_len(&self) -> usize);
-    delegate!(pub fn entry(&self, idx: usize) -> Entry<'_>);
+    delegate!(pub fn subentries_len(&self, idx: usize) -> usize);
+    delegate!(pub fn entry(&self, idx: usize, subidx: usize) -> Entry<'_>);
 
     pub fn text_entries(&self) -> impl Iterator<Item = &str> + ExactSizeIterator + '_ {
         match self {

--- a/src/mode/apps.rs
+++ b/src/mode/apps.rs
@@ -66,7 +66,8 @@ impl AppsMode {
         let entry = &self.entries[idx];
 
         Entry {
-            name: entry.name(subidx),
+            name: entry.entry.name.as_ref(),
+            subname: Some(entry.subname(subidx).unwrap_or("Default Action")),
             icon: entry.icon(subidx).map(|i| i.as_image()),
         }
     }

--- a/src/mode/apps.rs
+++ b/src/mode/apps.rs
@@ -29,7 +29,13 @@ impl AppsMode {
     pub fn eval(&mut self, info: EvalInfo<'_>) -> std::convert::Infallible {
         let idx = info.index.unwrap();
         let entry = &self.entries[idx];
-        let args = shlex::split(&entry.exec)
+        let exec = if info.subindex == 0 {
+            &entry.entry.exec
+        } else {
+            &entry.actions[info.subindex - 1].exec
+        };
+
+        let args = shlex::split(exec)
             .unwrap()
             .into_iter()
             .filter(|s| !s.starts_with('%')) // TODO: use placeholders somehow
@@ -52,12 +58,16 @@ impl AppsMode {
         self.entries.len()
     }
 
-    pub fn entry(&self, idx: usize) -> Entry<'_> {
+    pub fn subentries_len(&self, idx: usize) -> usize {
+        self.entries.get(idx).map(|e| e.actions.len()).unwrap_or(0)
+    }
+
+    pub fn entry(&self, idx: usize, subidx: usize) -> Entry<'_> {
         let entry = &self.entries[idx];
 
         Entry {
-            name: entry.name.as_str(),
-            icon: entry.icon.as_ref().map(|i| i.as_image()),
+            name: entry.name(subidx),
+            icon: entry.icon(subidx).map(|i| i.as_image()),
         }
     }
 

--- a/src/mode/bins.rs
+++ b/src/mode/bins.rs
@@ -103,7 +103,11 @@ impl BinsMode {
         self.bins.len()
     }
 
-    pub fn entry(&self, idx: usize) -> Entry<'_> {
+    pub fn subentries_len(&self, _: usize) -> usize {
+        0
+    }
+
+    pub fn entry(&self, idx: usize, _: usize) -> Entry<'_> {
         let bin = &self.bins[idx];
         let fname = bin.file_name().unwrap();
 
@@ -111,7 +115,8 @@ impl BinsMode {
             name.as_str()
         } else {
             fname.to_str().unwrap()
-        };
+        }
+        .to_owned();
 
         Entry { name, icon: None }
     }

--- a/src/mode/bins.rs
+++ b/src/mode/bins.rs
@@ -115,10 +115,13 @@ impl BinsMode {
             name.as_str()
         } else {
             fname.to_str().unwrap()
-        }
-        .to_owned();
+        };
 
-        Entry { name, icon: None }
+        Entry {
+            name,
+            subname: None,
+            icon: None,
+        }
     }
 
     pub fn text_entries(&self) -> impl Iterator<Item = &str> + super::ExactSizeIterator {

--- a/src/mode/dialog.rs
+++ b/src/mode/dialog.rs
@@ -32,9 +32,13 @@ impl DialogMode {
         self.lines.len()
     }
 
-    pub fn entry(&self, idx: usize) -> Entry<'_> {
+    pub fn subentries_len(&self, _: usize) -> usize {
+        0
+    }
+
+    pub fn entry(&self, idx: usize, _: usize) -> Entry<'_> {
         Entry {
-            name: self.lines[idx].as_str(),
+            name: self.lines[idx].clone(),
             icon: None,
         }
     }

--- a/src/mode/dialog.rs
+++ b/src/mode/dialog.rs
@@ -38,7 +38,8 @@ impl DialogMode {
 
     pub fn entry(&self, idx: usize, _: usize) -> Entry<'_> {
         Entry {
-            name: self.lines[idx].clone(),
+            name: self.lines[idx].as_ref(),
+            subname: None,
             icon: None,
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,6 +50,7 @@ impl Preprocessed {
                 let e = mode.entry(r.candidate_index, if idx == item { subitem } else { 0 });
                 ListItem {
                     name: e.name,
+                    subname: e.subname,
                     icon: e.icon,
                     match_mask: Some(&r.match_mask),
                 }
@@ -58,6 +59,7 @@ impl Preprocessed {
                 let e = mode.entry(i, if idx == item { subitem } else { 0 });
                 ListItem {
                     name: e.name,
+                    subname: e.subname,
                     icon: e.icon,
                     match_mask: None,
                 }


### PR DESCRIPTION
With default config looks this way:

<details>

![Screenshot_2022 01 29_20:55:00](https://user-images.githubusercontent.com/5658339/151671904-b2f765c0-4967-4efe-a09a-ffb4a2bbfe99.png)

![Screenshot_2022 01 29_20:55:10](https://user-images.githubusercontent.com/5658339/151671907-f0b7e036-48fc-4619-b770-c20741d2a45a.png)

</details>

`list_items.action_left_margin` config value could be used for changing action entry position (by default it's 60px).

Resolves #65 
