### PR TITLE
add explicit allsorts dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +47,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
 
 [[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allsorts"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1af358e0b1087dc76301fa24db610418a37c17af6d5b93e02ee7f64ba64290"
+dependencies = [
+ "bitflags",
+ "bitreader",
+ "brotli-decompressor",
+ "byteorder",
+ "encoding_rs",
+ "flate2",
+ "glyph-names",
+ "itertools",
+ "lazy_static",
+ "libc",
+ "log",
+ "num-traits",
+ "ouroboros",
+ "pathfinder_geometry",
+ "rustc-hash",
+ "tinyvec",
+ "ucd-trie",
+ "unicode-canonical-combining-class",
+ "unicode-general-category 0.5.1",
+ "unicode-joining-type 0.6.0",
+]
+
+[[package]]
 name = "allsorts-rental"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,8 +116,8 @@ dependencies = [
  "rustc-hash",
  "tinyvec",
  "ucd-trie",
- "unicode-general-category",
- "unicode-joining-type",
+ "unicode-general-category 0.3.0",
+ "unicode-joining-type 0.5.0",
 ]
 
 [[package]]
@@ -182,6 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
  "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -612,6 +656,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -883,6 +928,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1170,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b8d98df258e762e901eb4349d66d5a5f5a7a994db8df82ff596011773be535"
 dependencies = [
  "loom",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeff60e3e37407a80ead3e9458145b456e978c4068cddbfea6afb48572962ca"
+dependencies = [
+ "ouroboros_macro",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1862,16 +1941,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-canonical-combining-class"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b096a36c3e75936616680e901b5e08c180f102ec6626249b4dd12f46b9d48e1"
+
+[[package]]
 name = "unicode-general-category"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1e2c61f9441613aca1a1c88803bb36df292990aada6abb5133b9b532e07ec"
 
 [[package]]
+name = "unicode-general-category"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1218098468b8085b19a2824104c70d976491d247ce194bbd9dc77181150cdfd6"
+
+[[package]]
 name = "unicode-joining-type"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f679bc6da501427c9911a6f7fdb0e35238d49fecda2c80704042442233bebda"
+
+[[package]]
+name = "unicode-joining-type"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e069b4c5aba86d99ec9fc1b6d208b8b582f46c5d29a3cd7f3fd6806249fa50d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1929,6 +2026,12 @@ dependencies = [
  "ctor",
  "version_check",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -2112,6 +2215,7 @@ checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 name = "yofi"
 version = "0.1.5"
 dependencies = [
+ "allsorts",
  "anyhow",
  "bit-vec",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ fontdue = { version = "0.6.2", optional = true }
 rust-fontconfig = { version = "0.1.5", optional = true }
 encoding_rs = "=0.8.28"
 
+allsorts = "0.8.0"
 anyhow = "1.0.51"
 wayland-protocols = { version = "0.29.1", default-features = false, features = ["unstable_protocols", "client"] }
 sctk = { version = "0.15.2", package = "smithay-client-toolkit", features = ["calloop"] }


### PR DESCRIPTION
Hi,

On the current master, in my system, `yofi` panics.

It looks like one dependency is trying to make `no_std` stuff in a wrong way:
https://github.com/l4l/yofi/blob/074a76b91b9a6cb16a302dd78a71c63941ad0fab/Cargo.lock#L54

This dependency is not even owned on crates.io by its authors: https://github.com/yeslogic/allsorts/issues/49

This PR workaround this issue by explicitly adding the right `allsorts` as a dependency. After this, `yofi` works as expected for me.

For reference, on my system with `rustc 1.59.0 (9d1b2106e 2022-02-23)`:
<details>
<summary>show backtrace</summary>
<pre>
$ RUST_BACKTRACE=1 ./target/debug/yofi
thread '<unnamed>' panicked at 'Must provide allocators in no-stdlib code', /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-decompressor-2.3.2/src/ffi/alloc_util.rs:185:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
   2: core::panicking::panic
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:48:5
   3: <brotli_decompressor::ffi::alloc_util::SubclassableAllocator as alloc_no_stdlib::stack_allocator::Allocator<Ty>>::alloc_cell
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-decompressor-2.3.2/src/ffi/alloc_util.rs:185:13
   4: brotli_decompressor::state::BrotliState<AllocU8,AllocU32,AllocHC>::new_with_custom_dictionary
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-decompressor-2.3.2/src/state.rs:403:36
   5: brotli_decompressor::ffi::BrotliDecoderCreateInstance::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-decompressor-2.3.2/src/ffi/mod.rs:75:23
   6: brotli_decompressor::ffi::catch_panic_state
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-decompressor-2.3.2/src/ffi/mod.rs:208:8
   7: BrotliDecoderCreateInstance
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-decompressor-2.3.2/src/ffi/mod.rs:66:11
   8: allsorts_no_std::woff2::decode_brotli_stream
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/allsorts_no_std-0.5.2/src/woff2.rs:151:21
   9: <allsorts_no_std::woff2::Woff2Font as allsorts_no_std::binary::read::ReadBinary>::read
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/allsorts_no_std-0.5.2/src/woff2.rs:275:40
  10: <allsorts_no_std::font_data::FontData as allsorts_no_std::binary::read::ReadBinary>::read
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/allsorts_no_std-0.5.2/src/font_data.rs:34:48
  11: <T as allsorts_no_std::binary::read::ReadBinaryDep>::read_dep
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/allsorts_no_std-0.5.2/src/binary/read.rs:137:9
  12: allsorts_no_std::binary::read::ReadCtxt::read
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/allsorts_no_std-0.5.2/src/binary/read.rs:367:9
  13: allsorts_no_std::binary::read::ReadScope::read
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/allsorts_no_std-0.5.2/src/binary/read.rs:278:9
  14: rust_fontconfig::FcParseFont
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rust-fontconfig-0.1.5/src/lib.rs:398:21
  15: rust_fontconfig::FcParseFontFiles::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rust-fontconfig-0.1.5/src/lib.rs:363:24
  16: <rayon::iter::filter_map::FilterMapFolder<C,P> as rayon::iter::plumbing::Folder<T>>::consume
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/filter_map.rs:123:36
  17: rayon::iter::plumbing::Folder::consume_iter
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:179:20
  18: rayon::iter::plumbing::Producer::fold_with
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:110:9
  19: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:438:13
  20: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:427:21
  21: rayon_core::join::join_context::call_b::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:129:25
  22: rayon_core::job::StackJob<L,F,R>::run_inline
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:97:9
  23: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:158:36
  24: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  25: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  26: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  27: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:427:21
  28: rayon_core::join::join_context::call_b::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:129:25
  29: rayon_core::job::StackJob<L,F,R>::run_inline
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:97:9
  30: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:158:36
  31: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  32: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  33: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  34: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:427:21
  35: rayon_core::join::join_context::call_b::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:129:25
  36: rayon_core::job::StackJob<L,F,R>::run_inline
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:97:9
  37: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:158:36
  38: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  39: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  40: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  41: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:418:21
  42: rayon_core::join::join_context::call_a::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:124:17
  43: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panic/unwind_safe.rs:271:9
  44: std::panicking::try::do_call
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:406:40
  45: __rust_try
  46: std::panicking::try
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:370:19
  47: std::panic::catch_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panic.rs:133:14
  48: rayon_core::unwind::halt_unwinding
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/unwind.rs:17:5
  49: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:141:24
  50: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  51: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  52: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  53: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:427:21
  54: rayon_core::join::join_context::call_b::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:129:25
  55: rayon_core::job::StackJob<L,F,R>::run_inline
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:97:9
  56: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:158:36
  57: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  58: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  59: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  60: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:427:21
  61: rayon_core::join::join_context::call_b::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:129:25
  62: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute::call::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:113:21
  63: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panic/unwind_safe.rs:271:9
  64: std::panicking::try::do_call
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:406:40
  65: __rust_try
  66: std::panicking::try
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:370:19
  67: std::panic::catch_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panic.rs:133:14
  68: rayon_core::unwind::halt_unwinding
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/unwind.rs:17:5
  69: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:119:38
  70: rayon_core::job::JobRef::execute
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:59:9
  71: rayon_core::registry::WorkerThread::execute
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:749:9
  72: rayon_core::registry::WorkerThread::wait_until_cold
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:726:17
  73: rayon_core::registry::WorkerThread::wait_until
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:700:13
  74: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:166:17
  75: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  76: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  77: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  78: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:418:21
  79: rayon_core::join::join_context::call_a::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:124:17
  80: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panic/unwind_safe.rs:271:9
  81: std::panicking::try::do_call
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:406:40
  82: __rust_try
  83: std::panicking::try
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:370:19
  84: std::panic::catch_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panic.rs:133:14
  85: rayon_core::unwind::halt_unwinding
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/unwind.rs:17:5
  86: rayon_core::join::join_context::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:141:24
  87: rayon_core::registry::in_worker
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/registry.rs:875:13
  88: rayon_core::join::join_context
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:132:5
  89: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:416:47
  90: rayon::iter::plumbing::bridge_producer_consumer::helper::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.1/src/iter/plumbing/mod.rs:427:21
  91: rayon_core::join::join_context::call_b::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/join/mod.rs:129:25
  92: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute::call::{{closure}}
             at /home/gsaurel/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.1/src/job.rs:113:21
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
</pre>
</details>