### PR TITLE
Filter binapps with is_file()

### DIFF
--- a/src/mode/bins.rs
+++ b/src/mode/bins.rs
@@ -30,7 +30,7 @@ impl BinsMode {
             .flatten()
             .filter_map(|f| {
                 let meta = f.metadata().ok()?;
-                if meta.permissions().mode() & 0o001 > 0 {
+                if meta.is_file() && meta.permissions().mode() & 0o001 > 0 {
                     let p = f.path();
                     p.file_name()?;
                     Some(p)


### PR DESCRIPTION
`$PATH` may contain folders which usually have the executable bit set, this PR simply checks for `is_file()`.