### PR TITLE
Fix binapp symlinks

### DIFF
--- a/src/mode/bins.rs
+++ b/src/mode/bins.rs
@@ -30,7 +30,7 @@ impl BinsMode {
             .flatten()
             .filter_map(|f| {
                 let meta = f.metadata().ok()?;
-                if meta.is_file() && meta.permissions().mode() & 0o001 > 0 {
+                if f.path().is_file() && meta.permissions().mode() & 0o001 > 0 {
                     let p = f.path();
                     p.file_name()?;
                     Some(p)


### PR DESCRIPTION
Turns out the `is_file` implementation of `Metadata` does not follow symlinks and therefore returns `false` for them unlike the `Path` implementation.