### PR TITLE
Added brotli-decompressor dependency to fix issue with rust-fontconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
 
 [[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allsorts-rental"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
  "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2061,6 +2071,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "bit-vec",
+ "brotli-decompressor",
  "chrono",
  "defaults",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ ttf-parser = { version = "0.15.0", optional = true }
 
 fontdue = { version = "0.7.2", optional = true }
 rust-fontconfig = { version = "0.1.5", optional = true }
+# Not used directly by yofi. Added to ensure brotli-decompressor is built with std support for rust-fontconfig
+brotli-decompressor = { version = "*", optional = true }
 encoding_rs = "=0.8.28"
+
 
 anyhow = "1.0.51"
 wayland-protocols = { version = "0.29.1", default-features = false, features = ["unstable_protocols", "client"] }
@@ -53,7 +56,7 @@ lto = true
 
 [features]
 default = ["font-fontdue"]
-font-fontdue = ["fontdue", "rust-fontconfig"]
+font-fontdue = ["fontdue", "rust-fontconfig", "brotli-decompressor"]
 font-fontkit = ["font-kit", "pathfinder_geometry", "raqote/text", "ttf-parser"]
 
 [dev-dependencies]


### PR DESCRIPTION
Added `brotli-decompressor` as an optional dependency to enable its default features. It is only needed when `rust-fontconfig` is being used. If not specified it is built with no-std support and causes a runtime error due to a missing allocator.

Resolves #105

Link #88