### PR TITLE
Using fork() on Ctrl+Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased changes
 
+## Features
+
+- Launch multiple apps from one yofi launch based on fork (#24).
+
 ## Changes
 
 - Dropped support for font-kit backend.

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -71,6 +71,17 @@ impl Mode {
         Self::Dialog(dialog::DialogMode::new())
     }
 
+    pub fn fork_eval(&mut self, info: EvalInfo<'_>) {
+        match unsafe { nix::unistd::fork() } {
+            Ok(v) => {
+                if v.is_child() {
+                    self.eval(info);
+                }
+            }
+            Err(e) => log::error!("fork() error: {}", e),
+        }
+    }
+
     delegate!(pub fn eval(&mut self, info: EvalInfo<'_>) -> std::convert::Infallible);
     delegate!(pub fn entries_len(&self) -> usize);
     delegate!(pub fn subentries_len(&self, idx: usize) -> usize);

--- a/src/state.rs
+++ b/src/state.rs
@@ -186,16 +186,7 @@ impl State {
                     input_value: self.input_buffer.parsed_input(),
                 };
                 if ctrl {
-                    match unsafe { nix::unistd::fork() } {
-                        Ok(v) => {
-                            if v.is_child() {
-                                self.inner.eval(info);
-                            } else {
-                                return false;
-                            }
-                        }
-                        Err(e) => log::debug!("fork() error: {:?}", e),
-                    }
+                    self.inner.fork_eval(info);
                 } else {
                     self.inner.eval(info);
                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -177,7 +177,7 @@ impl State {
             }
             KeyPress {
                 keysym: keysyms::XKB_KEY_Return,
-                ctrl, 
+                ctrl,
                 ..
             } => {
                 let info = EvalInfo {
@@ -186,7 +186,16 @@ impl State {
                     input_value: self.input_buffer.parsed_input(),
                 };
                 if ctrl {
-                    // TODO: fork()
+                    match unsafe { nix::unistd::fork() } {
+                        Ok(v) => {
+                            if v.is_child() {
+                                self.inner.eval(info);
+                            } else {
+                                return false;
+                            }
+                        }
+                        Err(e) => log::debug!("fork() error: {:?}", e),
+                    }
                 } else {
                     self.inner.eval(info);
                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -177,6 +177,7 @@ impl State {
             }
             KeyPress {
                 keysym: keysyms::XKB_KEY_Return,
+                ctrl, 
                 ..
             } => {
                 let info = EvalInfo {
@@ -184,7 +185,11 @@ impl State {
                     subindex: self.selected_subitem,
                     input_value: self.input_buffer.parsed_input(),
                 };
-                self.inner.eval(info);
+                if ctrl {
+                    // TODO: fork()
+                } else {
+                    self.inner.eval(info);
+                }
             }
             KeyPress {
                 keysym: keysyms::XKB_KEY_bracketright,


### PR DESCRIPTION
Close #24.
I've looked through the code and found that using `fork()` right before [execvp*()](https://github.com/l4l/yofi/blob/master/src/exec.rs#L45) requires replacing [exec()](https://github.com/l4l/yofi/blob/master/src/exec.rs#L5) return type `std::convert::Infallible` with something else. So, instead I use `fork()` right after Ctrl+Enter was detected. 