### PR TITLE
Add corner_radius parameter for window and input box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Launch multiple apps from one yofi launch based on fork (#24).
 - Nix build (#98).
+- Corner roundings config param.
 
 ## Changes
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use defaults::Defaults;
 use serde::Deserialize;
 
-use crate::style::{Margin, Padding};
+use crate::style::{Margin, Padding, Radius};
 use crate::Color;
 
 const DEFAULT_CONFIG_NAME: &str = concat!(crate::prog_name!(), ".config");
@@ -35,6 +35,8 @@ pub struct Config {
     font_size: Option<u16>,
     bg_color: Option<Color>,
     font_color: Option<Color>,
+    #[def = "Radius::all(0.0)"]
+    corner_radius: Radius,
 
     icon: Option<Icon>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,8 @@ struct InputText {
     margin: Margin,
     #[def = "Padding::from_pair(1.7, -4.0)"]
     padding: Padding,
+    #[def = "Radius::all(f32::MAX)"]
+    corner_radius: Radius,
 }
 
 #[derive(Defaults, Deserialize)]

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -86,6 +86,9 @@ impl<'a> From<&'a Config> for ListParams {
 impl<'a> From<&'a Config> for BgParams {
     fn from(config: &'a Config) -> BgParams {
         BgParams {
+            width: config.width,
+            height: config.height,
+            radius: config.corner_radius.clone(),
             color: config.bg_color.unwrap_or(DEFAULT_BG_COLOR),
         }
     }

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -47,6 +47,7 @@ impl<'a> From<&'a Config> for InputTextParams<'a> {
             password: config.input_text.password,
             margin: config.input_text.margin.clone(),
             padding: config.input_text.padding.clone(),
+            radius: config.input_text.corner_radius.clone(),
         }
     }
 }

--- a/src/draw/background.rs
+++ b/src/draw/background.rs
@@ -1,8 +1,6 @@
-use std::f32::consts;
+use raqote::{Point, SolidSource};
 
-use raqote::{DrawOptions, PathBuilder, Point, Source};
-
-use super::{DrawTarget, Drawable, Space};
+use super::{DrawTarget, Drawable, RoundedRect, Space};
 use crate::{style::Radius, Color};
 
 pub struct Params {
@@ -12,58 +10,32 @@ pub struct Params {
     pub radius: Radius,
 }
 
-pub struct Background<'a> {
-    params: &'a Params,
+pub struct Background {
+    rect: RoundedRect,
 }
 
-impl<'a> Background<'a> {
-    pub fn new(params: &'a Params) -> Self {
-        Self { params }
+impl Background {
+    pub fn new(params: &Params) -> Self {
+        let color = params.color;
+        let radius = params.radius.clone();
+
+        Self {
+            rect: RoundedRect::new(radius, color),
+        }
     }
 }
 
-impl Drawable for Background<'_> {
-    fn draw(self, dt: &mut DrawTarget<'_>, _: u16, _: Space, _: Point) -> Space {
-        let mut pb = PathBuilder::new();
+impl Drawable for Background {
+    fn draw(self, dt: &mut DrawTarget<'_>, scale: u16, space: Space, start_point: Point) -> Space {
+        // Clear the draw target to avoid artefacts for scales > 1 in the corners
+        dt.clear(SolidSource {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        });
 
-        let width = self.params.width as f32;
-        let height = self.params.height as f32;
-        let Radius {
-            top_left,
-            top_right,
-            bottom_left,
-            bottom_right,
-        } = self.params.radius;
-
-        pb.arc(top_left, top_left, top_left, consts::PI, consts::FRAC_PI_2);
-        pb.arc(
-            width - top_right,
-            top_right,
-            top_right,
-            3.0 * consts::FRAC_PI_2,
-            consts::FRAC_PI_2,
-        );
-        pb.arc(
-            width - bottom_right,
-            height - bottom_right,
-            bottom_right,
-            2.0 * consts::PI,
-            consts::FRAC_PI_2,
-        );
-        pb.arc(
-            bottom_left,
-            height - bottom_left,
-            bottom_left,
-            consts::FRAC_PI_2,
-            consts::FRAC_PI_2,
-        );
-        let path = pb.finish();
-
-        dt.fill(
-            &path,
-            &Source::Solid(self.params.color.as_source()),
-            &DrawOptions::new(),
-        );
+        self.rect.draw(dt, scale, space, start_point);
 
         Space {
             width: 0.,

--- a/src/draw/background.rs
+++ b/src/draw/background.rs
@@ -1,10 +1,15 @@
-use raqote::Point;
+use std::f32::consts;
+
+use raqote::{DrawOptions, PathBuilder, Point, Source};
 
 use super::{DrawTarget, Drawable, Space};
-use crate::Color;
+use crate::{style::Radius, Color};
 
 pub struct Params {
+    pub width: u32,
+    pub height: u32,
     pub color: Color,
+    pub radius: Radius,
 }
 
 pub struct Background<'a> {
@@ -19,7 +24,46 @@ impl<'a> Background<'a> {
 
 impl Drawable for Background<'_> {
     fn draw(self, dt: &mut DrawTarget<'_>, _: u16, _: Space, _: Point) -> Space {
-        dt.clear(self.params.color.as_source());
+        let mut pb = PathBuilder::new();
+
+        let width = self.params.width as f32;
+        let height = self.params.height as f32;
+        let Radius {
+            top_left,
+            top_right,
+            bottom_left,
+            bottom_right,
+        } = self.params.radius;
+
+        pb.arc(top_left, top_left, top_left, consts::PI, consts::FRAC_PI_2);
+        pb.arc(
+            width - top_right,
+            top_right,
+            top_right,
+            3.0 * consts::FRAC_PI_2,
+            consts::FRAC_PI_2,
+        );
+        pb.arc(
+            width - bottom_right,
+            height - bottom_right,
+            bottom_right,
+            2.0 * consts::PI,
+            consts::FRAC_PI_2,
+        );
+        pb.arc(
+            bottom_left,
+            height - bottom_left,
+            bottom_left,
+            consts::FRAC_PI_2,
+            consts::FRAC_PI_2,
+        );
+        let path = pb.finish();
+
+        dt.fill(
+            &path,
+            &Source::Solid(self.params.color.as_source()),
+            &DrawOptions::new(),
+        );
 
         Space {
             width: 0.,

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -49,6 +49,9 @@ impl<'a> Drawable for InputText<'a> {
         let left_x_center = point.x + margin.left + border_radius;
         let y_center = point.y + margin.top + border_radius;
 
+        // this is necessary since we already used dt for the background
+        pb.move_to(left_x_center - border_radius, y_center + border_radius);
+
         pb.arc(
             left_x_center,
             y_center,

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -1,10 +1,8 @@
-use std::f32::consts;
+use raqote::{DrawOptions, Point};
 
-use raqote::{DrawOptions, PathBuilder, Point, Source};
-
-use super::{DrawTarget, Drawable, Space};
+use super::{DrawTarget, Drawable, RoundedRect, Space};
 use crate::font::{Font, FontBackend, FontColor};
-use crate::style::{Margin, Padding};
+use crate::style::{Margin, Padding, Radius};
 use crate::Color;
 
 pub struct Params<'a> {
@@ -17,23 +15,30 @@ pub struct Params<'a> {
     pub password: bool,
     pub margin: Margin,
     pub padding: Padding,
+    pub radius: Radius,
 }
 
 pub struct InputText<'a> {
     text: &'a str,
     params: &'a Params<'a>,
+    rect: RoundedRect,
 }
 
 impl<'a> InputText<'a> {
     pub fn new(text: &'a str, params: &'a Params<'a>) -> Self {
-        Self { text, params }
+        let color = params.bg_color;
+        let radius = params.radius.clone();
+
+        Self {
+            text,
+            params,
+            rect: RoundedRect::new(radius, color),
+        }
     }
 }
 
 impl<'a> Drawable for InputText<'a> {
     fn draw(self, dt: &mut DrawTarget<'_>, scale: u16, space: Space, point: Point) -> Space {
-        let mut pb = PathBuilder::new();
-
         let font_size = f32::from(self.params.font_size * scale);
 
         let mut padding = &self.params.padding * f32::from(scale);
@@ -43,43 +48,21 @@ impl<'a> Drawable for InputText<'a> {
         padding.bottom += PADDING_BOTTOM;
         let margin = &self.params.margin * f32::from(scale);
 
-        let border_diameter = padding.top + font_size + padding.bottom;
-        let border_radius = border_diameter / 2.0;
+        let rect_width = space.width - margin.left - margin.right;
+        let rect_height = padding.top + font_size + padding.bottom;
+        let rect_space = Space {
+            width: rect_width,
+            height: rect_height,
+        };
+        let rect_point = Point::new(point.x + margin.left, point.y + margin.top);
 
-        let left_x_center = point.x + margin.left + border_radius;
-        let y_center = point.y + margin.top + border_radius;
+        self.rect.draw(dt, scale, rect_space, rect_point);
 
-        // this is necessary since we already used dt for the background
-        pb.move_to(left_x_center - border_radius, y_center + border_radius);
+        padding.left += (rect_height / 2.0)
+            .min(self.params.radius.top_left)
+            .min(self.params.radius.top_right);
 
-        pb.arc(
-            left_x_center,
-            y_center,
-            border_radius,
-            consts::FRAC_PI_2,
-            consts::PI,
-        );
-        let right_x_center = (point.x + space.width - border_radius - margin.right)
-            .max(left_x_center - border_radius);
-        pb.arc(
-            right_x_center,
-            y_center,
-            border_radius,
-            3.0 * consts::FRAC_PI_2,
-            consts::PI,
-        );
-        let path = pb.finish();
-
-        dt.fill(
-            &path,
-            &Source::Solid(self.params.bg_color.as_source()),
-            &DrawOptions::new(),
-        );
-
-        let pos = Point::new(
-            left_x_center + padding.left,
-            point.y + margin.top + padding.top,
-        );
+        let pos = Point::new(rect_point.x + padding.left, rect_point.y + padding.top);
 
         let password_text = if self.params.password {
             Some("*".repeat(self.text.chars().count()))
@@ -114,7 +97,7 @@ impl<'a> Drawable for InputText<'a> {
 
         Space {
             width: space.width,
-            height: point.y + margin.top + border_diameter + margin.bottom,
+            height: margin.top + rect_height + margin.bottom,
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -114,6 +114,15 @@ impl Radius {
             bottom_right: first,
         }
     }
+
+    pub(crate) fn min(&self, other: Radius) -> Radius {
+        Self {
+            top_left: self.top_left.min(other.top_left),
+            top_right: self.top_right.min(other.top_right),
+            bottom_left: self.bottom_left.min(other.bottom_left),
+            bottom_right: self.bottom_right.min(other.bottom_right),
+        }
+    }
 }
 
 impl Mul<f32> for &Margin {


### PR DESCRIPTION
This pull request adds the configuration parameter `corner_radius` for both the main application window as well as the input text field.

Minimal `yofi.config`:

```
corner_radius = "20"

[input_text]
corner_radius = "15 5 0 0"
```

The corner radius can be specified using one, two or four values with the same behavior as the CSS `border-radius` property (one value applies to all corners, two to opposite ones, and four to each corner separately in the order top-left, top-right, bottom-right, bottom-left).

The default behavior (no rounded corners for the application window, fully rounded ones for the input box) remains unchanged.

Resolves #6 and resolves #41.
