### PR TITLE
Add background border

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,9 @@ const DEFAULT_FONT_COLOR: Color = Color::from_rgba(0xf8, 0xf8, 0xf2, 0xff);
 const DEFAULT_BG_COLOR: Color = Color::from_rgba(0x27, 0x28, 0x22, 0xee);
 const DEFAULT_INPUT_BG_COLOR: Color = Color::from_rgba(0x75, 0x71, 0x5e, 0xc0);
 const DEFAULT_SELECTED_FONT_COLOR: Color = Color::from_rgba(0xa6, 0xe2, 0x2e, 0xff);
+
 const DEFAULT_BG_BORDER_COLOR: Color = Color::from_rgba(0x13, 0x14, 0x11, 0xff);
+const DEFAULT_BG_BORDER_WIDTH: f32 = 2.0;
 
 mod params;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ const DEFAULT_FONT_COLOR: Color = Color::from_rgba(0xf8, 0xf8, 0xf2, 0xff);
 const DEFAULT_BG_COLOR: Color = Color::from_rgba(0x27, 0x28, 0x22, 0xee);
 const DEFAULT_INPUT_BG_COLOR: Color = Color::from_rgba(0x75, 0x71, 0x5e, 0xc0);
 const DEFAULT_SELECTED_FONT_COLOR: Color = Color::from_rgba(0xa6, 0xe2, 0x2e, 0xff);
-const DEFAULT_BG_BORDER_COLOR: Color = Color::from_rgba(0xfe, 0x11, 0x11, 0xff);
+const DEFAULT_BG_BORDER_COLOR: Color = Color::from_rgba(0x13, 0x14, 0x11, 0xff);
 
 mod params;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ const DEFAULT_FONT_COLOR: Color = Color::from_rgba(0xf8, 0xf8, 0xf2, 0xff);
 const DEFAULT_BG_COLOR: Color = Color::from_rgba(0x27, 0x28, 0x22, 0xee);
 const DEFAULT_INPUT_BG_COLOR: Color = Color::from_rgba(0x75, 0x71, 0x5e, 0xc0);
 const DEFAULT_SELECTED_FONT_COLOR: Color = Color::from_rgba(0xa6, 0xe2, 0x2e, 0xff);
+const DEFAULT_BG_BORDER_COLOR: Color = Color::from_rgba(0xfe, 0x11, 0x11, 0xff);
 
 mod params;
 
@@ -34,6 +35,8 @@ pub struct Config {
     font: Option<String>,
     font_size: Option<u16>,
     bg_color: Option<Color>,
+    bg_border_color: Option<Color>,
+    bg_border_width: Option<f32>,
     font_color: Option<Color>,
     #[def = "Radius::all(0.0)"]
     corner_radius: Radius,

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -92,7 +92,7 @@ impl<'a> From<&'a Config> for BgParams {
             radius: config.corner_radius.clone(),
             color: config.bg_color.unwrap_or(DEFAULT_BG_COLOR),
             border_color: config.bg_border_color.unwrap_or(DEFAULT_BG_BORDER_COLOR),
-            border_width: config.bg_border_width.unwrap_or(2.0),
+            border_width: config.bg_border_width.unwrap_or(0.0),
         }
     }
 }

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -86,13 +86,18 @@ impl<'a> From<&'a Config> for ListParams {
 
 impl<'a> From<&'a Config> for BgParams {
     fn from(config: &'a Config) -> BgParams {
+        let border = match (config.bg_border_color, config.bg_border_width) {
+            (None, None) => None,
+            (Some(c), Some(w)) => Some((c, w)),
+            (Some(c), None) => Some((c, DEFAULT_BG_BORDER_WIDTH)),
+            (None, Some(w)) => Some((DEFAULT_BG_BORDER_COLOR, w)),
+        };
         BgParams {
             width: config.width,
             height: config.height,
             radius: config.corner_radius.clone(),
             color: config.bg_color.unwrap_or(DEFAULT_BG_COLOR),
-            border_color: config.bg_border_color.unwrap_or(DEFAULT_BG_BORDER_COLOR),
-            border_width: config.bg_border_width.unwrap_or(0.0),
+            border,
         }
     }
 }

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -91,6 +91,8 @@ impl<'a> From<&'a Config> for BgParams {
             height: config.height,
             radius: config.corner_radius.clone(),
             color: config.bg_color.unwrap_or(DEFAULT_BG_COLOR),
+            border_color: config.bg_border_color.unwrap_or(DEFAULT_BG_BORDER_COLOR),
+            border_width: config.bg_border_width.unwrap_or(2.0),
         }
     }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -2,7 +2,7 @@ use std::f32::consts;
 
 use oneshot::Sender;
 pub use raqote::Point;
-use raqote::{DrawOptions, PathBuilder, Source};
+use raqote::{DrawOptions, PathBuilder, Source, StrokeStyle};
 
 pub use background::Params as BgParams;
 pub use input_text::Params as InputTextParams;
@@ -143,6 +143,16 @@ impl Drawable for RoundedRect {
         dt.fill(
             &path,
             &Source::Solid(self.color.as_source()),
+            &DrawOptions::new(),
+        );
+
+        dt.stroke(
+            &path,
+            &Source::Solid(self.border_color.as_source()),
+            &StrokeStyle {
+                width: self.border_width,
+                ..Default::default()
+            },
             &DrawOptions::new(),
         );
         space

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -2,7 +2,7 @@ use std::f32::consts;
 
 use oneshot::Sender;
 pub use raqote::Point;
-use raqote::{DrawOptions, PathBuilder, Source, StrokeStyle};
+use raqote::{DrawOptions, Path, PathBuilder, Source, StrokeStyle};
 
 pub use background::Params as BgParams;
 pub use input_text::Params as InputTextParams;
@@ -76,18 +76,20 @@ where
 pub struct RoundedRect {
     radius: Radius,
     color: Color,
-    border_color: Color,
-    border_width: f32,
+    border: Option<Border>,
 }
 
 impl RoundedRect {
-    fn new(radius: Radius, color: Color, border_color: Color, border_width: f32) -> Self {
+    fn new(radius: Radius, color: Color) -> Self {
         Self {
             radius,
             color,
-            border_color,
-            border_width,
+            border: None,
         }
+    }
+
+    fn with_border(self, border: Option<Border>) -> Self {
+        Self { border, ..self }
     }
 }
 
@@ -147,8 +149,30 @@ impl Drawable for RoundedRect {
             &DrawOptions::new(),
         );
 
+        if let Some(b) = self.border {
+            b.add_stroke(dt, &path);
+        }
+
+        space
+    }
+}
+
+pub struct Border {
+    border_color: Color,
+    border_width: f32,
+}
+
+impl Border {
+    pub fn new(border_color: Color, border_width: f32) -> Self {
+        Self {
+            border_color,
+            border_width,
+        }
+    }
+
+    fn add_stroke(self, dt: &mut DrawTarget<'_>, path: &Path) {
         dt.stroke(
-            &path,
+            path,
             &Source::Solid(self.border_color.as_source()),
             &StrokeStyle {
                 width: self.border_width,
@@ -156,6 +180,5 @@ impl Drawable for RoundedRect {
             },
             &DrawOptions::new(),
         );
-        space
     }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -76,11 +76,18 @@ where
 pub struct RoundedRect {
     radius: Radius,
     color: Color,
+    border_color: Color,
+    border_width: f32,
 }
 
 impl RoundedRect {
-    fn new(radius: Radius, color: Color) -> Self {
-        Self { radius, color }
+    fn new(radius: Radius, color: Color, border_color: Color, border_width: f32) -> Self {
+        Self {
+            radius,
+            color,
+            border_color,
+            border_width,
+        }
     }
 }
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -138,6 +138,7 @@ impl Drawable for RoundedRect {
             consts::FRAC_PI_2,
             consts::FRAC_PI_2,
         );
+        pb.line_to(x, y + top_left);
         let path = pb.finish();
 
         dt.fill(

--- a/src/draw/background.rs
+++ b/src/draw/background.rs
@@ -1,6 +1,6 @@
 use raqote::{Point, SolidSource};
 
-use super::{DrawTarget, Drawable, RoundedRect, Space};
+use super::{Border, DrawTarget, Drawable, RoundedRect, Space};
 use crate::{style::Radius, Color};
 
 pub struct Params {
@@ -8,8 +8,7 @@ pub struct Params {
     pub height: u32,
     pub color: Color,
     pub radius: Radius,
-    pub border_color: Color,
-    pub border_width: f32,
+    pub border: Option<(Color, f32)>,
 }
 
 pub struct Background {
@@ -20,10 +19,14 @@ impl Background {
     pub fn new(params: &Params) -> Self {
         let color = params.color;
         let radius = params.radius.clone();
+        let border = if let Some((c, w)) = params.border {
+            Some(Border::new(c, w))
+        } else {
+            None
+        };
+        let rect = RoundedRect::new(radius, color).with_border(border);
 
-        Self {
-            rect: RoundedRect::new(radius, color, params.border_color, params.border_width),
-        }
+        Self { rect }
     }
 }
 

--- a/src/draw/background.rs
+++ b/src/draw/background.rs
@@ -8,6 +8,8 @@ pub struct Params {
     pub height: u32,
     pub color: Color,
     pub radius: Radius,
+    pub border_color: Color,
+    pub border_width: f32,
 }
 
 pub struct Background {
@@ -20,7 +22,7 @@ impl Background {
         let radius = params.radius.clone();
 
         Self {
-            rect: RoundedRect::new(radius, color),
+            rect: RoundedRect::new(radius, color, params.border_color, params.border_width),
         }
     }
 }

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -28,13 +28,11 @@ impl<'a> InputText<'a> {
     pub fn new(text: &'a str, params: &'a Params<'a>) -> Self {
         let color = params.bg_color;
         let radius = params.radius.clone();
-        let border_color = Color::from_rgba(0, 0, 0, 0);
-        let border_width = 0.0;
 
         Self {
             text,
             params,
-            rect: RoundedRect::new(radius, color, border_color, border_width),
+            rect: RoundedRect::new(radius, color),
         }
     }
 }

--- a/src/draw/input_text.rs
+++ b/src/draw/input_text.rs
@@ -28,11 +28,13 @@ impl<'a> InputText<'a> {
     pub fn new(text: &'a str, params: &'a Params<'a>) -> Self {
         let color = params.bg_color;
         let radius = params.radius.clone();
+        let border_color = Color::from_rgba(0, 0, 0, 0);
+        let border_width = 0.0;
 
         Self {
             text,
             params,
-            rect: RoundedRect::new(radius, color),
+            rect: RoundedRect::new(radius, color, border_color, border_width),
         }
     }
 }


### PR DESCRIPTION
This adds support for drawing borders around `RoundedRect`. I added two params `bg_border_color` and `bg_border_width` for background in the first commit. The defaults are red and 2.0 which is probably a bad idea. Would you rather disable the border per default? I.e. transparent color and 0.0 width.

The second commit draws the border just on the same path as the actual background. The left side is unfortunately not shown (see picture). I guess it lies *just* outside the background surface? Do you see a way to still re-use the background path for this?

![20230210-111538_grim](https://user-images.githubusercontent.com/28558894/218066527-8207d0b5-1ac2-4284-bf43-fa34a035ec69.png)

I didn't yet add support for borders on the input text, but this would be straightforward. Let me know if what you think about adding it on the input text, too.

Resolves #140 