### PR TITLE
add timeout to panic notification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,7 @@ fn main_inner() {
 }
 
 fn main() {
-    const NOTIFY_TIMEOUT: Duration = Duration::from_micros(500);
+    const NOTIFY_TIMEOUT: Duration = Duration::from_millis(250);
 
     let res = std::panic::catch_unwind(main_inner);
 


### PR DESCRIPTION
This fixes #148 

On panic we send a notification, but if not notification daemon is available we block on notify-send for a while, which leads to issues.