### PR TITLE
Support yofi.toml as config filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Log to stderr instead of stdout.
 - Prefer earlier match with same score for input search.
 - Empty subitems now hidden.
+- yofi.config is deprecated.
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add flag to hide input bar.
 - Adaptive height config option.
 - Quit on outer region click.
+- yofi.toml is now supported.
 
 ## Changes
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,10 +40,13 @@
 
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
-            rustc
             cargo
-            pkg-config
+            clippy
             libxkbcommon
+            pkg-config
+            rust-analyzer
+            rustc
+            rustfmt
           ];
 
           LD_LIBRARY_PATH = rpath;

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,10 @@ use serde::Deserialize;
 use crate::style::{Margin, Padding, Radius};
 use crate::Color;
 
-const DEFAULT_CONFIG_NAME: &str = concat!(crate::prog_name!(), ".config");
+const DEFAULT_CONFIG_NAMES: [&str; 2] = [
+    concat!(crate::prog_name!(), ".toml"),
+    concat!(crate::prog_name!(), ".config"),
+];
 
 const DEFAULT_ICON_SIZE: u16 = 16;
 const DEFAULT_FONT_SIZE: u16 = 24;
@@ -130,17 +133,20 @@ struct Mouse {
 }
 
 fn default_config_path() -> Result<Option<PathBuf>> {
-    let file = xdg::BaseDirectories::with_prefix(crate::prog_name!())
-        .context("failed to get xdg dirs")?
-        .get_config_file(DEFAULT_CONFIG_NAME);
-    if file
-        .try_exists()
-        .with_context(|| format!("reading default config at {}", file.display()))?
-    {
-        Ok(Some(file))
-    } else {
-        Ok(None)
+    let xdg_dirs =
+        xdg::BaseDirectories::with_prefix(crate::prog_name!()).context("failed to get xdg dirs")?;
+
+    for &filename in &DEFAULT_CONFIG_NAMES {
+        let file = xdg_dirs.get_config_file(filename);
+        if file
+            .try_exists()
+            .with_context(|| format!("reading default config at {}", file.display()))?
+        {
+            return Ok(Some(file));
+        }
     }
+
+    Ok(None)
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,12 +136,15 @@ fn default_config_path() -> Result<Option<PathBuf>> {
     let xdg_dirs =
         xdg::BaseDirectories::with_prefix(crate::prog_name!()).context("failed to get xdg dirs")?;
 
-    for &filename in &DEFAULT_CONFIG_NAMES {
+    for (index, &filename) in DEFAULT_CONFIG_NAMES.iter().enumerate() {
         let file = xdg_dirs.get_config_file(filename);
         if file
             .try_exists()
             .with_context(|| format!("reading default config at {}", file.display()))?
         {
+            if index != 0 {
+                eprintln!("warning: yofi.config is deprecated, please rename your configuration file to yofi.toml");
+            }
             return Ok(Some(file));
         }
     }


### PR DESCRIPTION
Allows editors to more easily syntax highlight. Didn't open an issue beforehand since this feature is so minor.