### PR TITLE
Fix build for Rust 1.80.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1167,9 +1167,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
Currently, the application fails to build on rust 1.80.0. This is due to the time crate failing during the build.
<details>

<summary>Error Log</summary>

```hs
 Compiling svgtypes v0.14.0
   Compiling simplecss v0.2.1
   Compiling time v0.3.34
   Compiling imagesize v0.12.0
   Compiling euclid v0.22.9
   Compiling regex-syntax v0.8.2
error[E0282]: type annotations needed for `Box<_>`
  --> /home/smj/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.34/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

   Compiling data-url v0.3.1
   Compiling pico-args v0.5.0
   Compiling anyhow v1.0.80
   Compiling base64 v0.21.7
   Compiling minimal-lexical v0.2.1
For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```
</details>

The crate time was updated to resolve this build issue. This PR just does that.
```hs
Updating time v0.3.34 -> v0.3.36
Updating time-macros v0.2.17 -> v0.2.18
```

Also fixes: https://github.com/NixOS/nixpkgs/issues/332957 for yofi.